### PR TITLE
Declare buffer local variables as global variable

### DIFF
--- a/magnatune.el
+++ b/magnatune.el
@@ -135,6 +135,13 @@ There are two functions provided:
 (defvar magnatune-column-width 80
   "Maxium columns used for displaying things.")
 
+(defvar magnatune--update-fn)
+(defvar magnatune--query)
+(defvar magnatune--offset)
+(defvar magnatune--limit)
+(defvar magnatune--order)
+(defvar magnatune--results)
+(defvar magnatune--truncated-items)
 
 
 (defun magnatune--make-url (url-fmt &rest args)


### PR DESCRIPTION
This is for suppressing byte-compile warnings.

There are many byte-compile warnings like following log.

```
magnatune.el:558:48:Warning: assignment to free variable `magnatune--query'
magnatune.el:560:50:Warning: assignment to free variable `magnatune--offset'
magnatune.el:561:58:Warning: assignment to free variable `magnatune--limit'
magnatune.el:559:30:Warning: assignment to free variable `magnatune--order'
magnatune.el:560:30:Warning: assignment to free variable `magnatune--results'
...
```
